### PR TITLE
Add YAML schema validation to CI process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,10 @@ name: CI
 
 on:
   push:
-    branches: [ "main" ]
-    tags: [ "v*" ]
+    branches: ["main"]
+    tags: ["v*"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
   workflow_dispatch:
 
 jobs:
@@ -14,6 +14,18 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Validate airports.yaml
+        uses: thiagodnf/yaml-schema-checker@v0.0.12
+        with:
+          jsonSchemaFile: schema/airports.schema.json
+          yamlFiles: airports.yaml
+
+      - name: Validate navaids.yaml
+        uses: thiagodnf/yaml-schema-checker@v0.0.12
+        with:
+          jsonSchemaFile: schema/navaids.schema.json
+          yamlFiles: navaids.yaml
 
       - name: Create airports.json
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Validate airports.yaml
         uses: thiagodnf/yaml-schema-checker@v0.0.12

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    name: "Validate and generate"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,13 +18,13 @@ jobs:
       - name: Validate airports.yaml
         uses: thiagodnf/yaml-schema-checker@v0.0.12
         with:
-          jsonSchemaFile: schema/airports.schema.json
+          jsonSchemaFile: schemas/airports.schema.json
           yamlFiles: airports.yaml
 
       - name: Validate navaids.yaml
         uses: thiagodnf/yaml-schema-checker@v0.0.12
         with:
-          jsonSchemaFile: schema/navaids.schema.json
+          jsonSchemaFile: schemas/navaids.schema.json
           yamlFiles: navaids.yaml
 
       - name: Create airports.json

--- a/schemas/airports.schema.json
+++ b/schemas/airports.schema.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "ID": {
+        "type": "string"
+      },
+      "Name": {
+        "type": "string"
+      },
+      "Lat": {
+        "type": "number"
+      },
+      "Lon": {
+        "type": "number"
+      }
+    },
+    "required": ["ID", "Name", "Lat", "Lon"]
+  }
+}

--- a/schemas/navaids.schema.json
+++ b/schemas/navaids.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "ID": {
+        "type": "string"
+      },
+      "Name": {
+        "type": "string"
+      }
+    },
+    "required": ["ID", "Name"]
+  }
+}


### PR DESCRIPTION
This PR adds two YAML validation steps to the existing CI process. This should guard against issues like the one introduced in #17.

* Adds schema files for airports.yml and navaids.yml
* Adds verification steps to the existing workflow, before the JSON files are generated
* Updates to actions/checkout@v4 to remove a warning since I was editing the workflow anyway

Here's an example of a failed run against the file checked in with #17: https://github.com/neilenns/navdata/actions/runs/10392918979/job/28779239721

![failure](https://github.com/user-attachments/assets/251be119-1755-45ed-94d3-b09ce836b34c)

Here's an example of a successful run against the current checked in yaml: https://github.com/neilenns/navdata/actions/runs/10392937229

The job is named "Validate and generate" and can be added as a required status check in GitHub's branch protection rules to guard against merges that fail validation.